### PR TITLE
Fix table_for

### DIFF
--- a/lib/express_templates/components/table_for.rb
+++ b/lib/express_templates/components/table_for.rb
@@ -80,7 +80,7 @@ module ExpressTemplates
           tbody {
             for_each("@#{my[:id]}".to_sym) {
 
-              tr(id: "#{my[:id].to_s.singularize}-#{-> {"#{my[:id].to_s.singularize}"}}",
+              tr(id: "#{my[:id].to_s.singularize}-{{#{my[:id].to_s.singularize}.id}}",
                  class: my[:id].to_s.singularize) {
 
                 columns.each do |column|

--- a/lib/express_templates/components/table_for.rb
+++ b/lib/express_templates/components/table_for.rb
@@ -80,12 +80,12 @@ module ExpressTemplates
           tbody {
             for_each("@#{my[:id]}".to_sym) {
 
-              tr(id: -> {"item-#{item.id}"},
+              tr(id: "#{my[:id].to_s.singularize}-#{-> {"#{my[:id].to_s.singularize}"}}",
                  class: my[:id].to_s.singularize) {
 
                 columns.each do |column|
                   td(class: column.name) {
-                    column.format(:item)
+                    column.format(my[:id].to_s.singularize)
                   }
                 end
               }

--- a/test/components/table_for_test.rb
+++ b/test/components/table_for_test.rb
@@ -17,7 +17,7 @@ class TableForTest < ActiveSupport::TestCase
 
   EXAMPLE_COMPILED = -> {
     ExpressTemplates::Components::TableFor.render_in(self) {
-      "<table id=\"test_items\">
+"<table id=\"test_items\">
   <thead>
     <tr>
       <th class=\"name\">Name</th>
@@ -26,17 +26,17 @@ class TableForTest < ActiveSupport::TestCase
   </thead>
 
   <tbody>"+(@test_items.each_with_index.map do |test_item, test_item_index|
-        "
-    <tr id=\"#{(-> {"test_item-#{test_item.id}"}).call}\" class=\"test_item\">
+"
+    <tr id=\"test_item-#{test_item.id}\" class=\"test_item\">
       <td class=\"name\">#{test_item.name}</td>
       <td class=\"price\">#{(-> (price) { '$%0.2f' % price }).call(test_item.price)}</td>
     </tr>
-        "
-      end).join+"  </tbody>
+"
+end).join+"  </tbody>
 </table>
-      "
-    }
-  }
+"
+}
+}
 
   EXAMPLE_MARKUP = <<-HTML
 <table id="test_items">

--- a/test/components/table_for_test.rb
+++ b/test/components/table_for_test.rb
@@ -4,20 +4,20 @@ require 'ostruct'
 class TableForTest < ActiveSupport::TestCase
 
   class Context
-    def initialize(items)
-      @items = items
+    def initialize(test_items)
+      @test_items = test_items
     end
   end
 
-  def items
+  def test_items
     [OpenStruct.new(id: 1, name: 'Foo', price: 1.23),
      OpenStruct.new(id: 2, name: 'Bar', price: 5.49),
      OpenStruct.new(id: 3, name: 'Baz', price: 99.97)]
   end
 
   EXAMPLE_COMPILED = -> {
-ExpressTemplates::Components::TableFor.render_in(self) {
-"<table id=\"items\">
+    ExpressTemplates::Components::TableFor.render_in(self) {
+      "<table id=\"test_items\">
   <thead>
     <tr>
       <th class=\"name\">Name</th>
@@ -25,21 +25,21 @@ ExpressTemplates::Components::TableFor.render_in(self) {
     </tr>
   </thead>
 
-  <tbody>"+(@items.each_with_index.map do |item, item_index|
-"
-    <tr id=\"#{(-> {"item-#{item.id}"}).call}\" class=\"item\">
-      <td class=\"name\">#{item.name}</td>
-      <td class=\"price\">#{(-> (price) { '$%0.2f' % price }).call(item.price)}</td>
+  <tbody>"+(@test_items.each_with_index.map do |test_item, test_item_index|
+        "
+    <tr id=\"#{(-> {"test_item-#{test_item.id}"}).call}\" class=\"test_item\">
+      <td class=\"name\">#{test_item.name}</td>
+      <td class=\"price\">#{(-> (price) { '$%0.2f' % price }).call(test_item.price)}</td>
     </tr>
-"
-end).join+"  </tbody>
+        "
+      end).join+"  </tbody>
 </table>
-"
-}
-}
+      "
+    }
+  }
 
   EXAMPLE_MARKUP = <<-HTML
-<table id="items">
+<table id="test_items">
   <thead>
     <tr>
       <th class="name">Name</th>
@@ -48,33 +48,33 @@ end).join+"  </tbody>
   </thead>
 
   <tbody>
-    <tr id="item-1" class="item">
+    <tr id="test_item-1" class="test_item">
       <td class="name">Foo</td>
       <td class="price">$1.23</td>
     </tr>
 
-    <tr id="item-2" class="item">
+    <tr id="test_item-2" class="test_item">
       <td class="name">Bar</td>
       <td class="price">$5.49</td>
     </tr>
 
-    <tr id="item-3" class="item">
+    <tr id="test_item-3" class="test_item">
       <td class="name">Baz</td>
       <td class="price">$99.97</td>
     </tr>
   </tbody>
 </table>
-HTML
+  HTML
 
 
-  def simple_table(items)
-    ctx = Context.new(items)
+  def simple_table(test_items)
+    ctx = Context.new(test_items)
     fragment = -> {
-                    table_for(:items) do |t|
-                      t.column :name, header: "Name"
-                      t.column :price, formatter: -> (price) { '$%0.2f' % price }
-                    end
-                  }
+      table_for(:test_items) do |t|
+        t.column :name, header: "Name"
+        t.column :price, formatter: -> (price) { '$%0.2f' % price }
+      end
+    }
     return ctx, fragment
   end
 
@@ -85,24 +85,24 @@ HTML
   end
 
   test "example view code evaluates to example markup" do
-    assert_equal EXAMPLE_MARKUP, Context.new(items).instance_eval(EXAMPLE_COMPILED.source_body)
+    assert_equal EXAMPLE_MARKUP, Context.new(test_items).instance_eval(EXAMPLE_COMPILED.source_body)
   end
 
   test "compiled source is legible and transparent" do
     ExpressTemplates::Markup::Tag.formatted do
-      ctx, fragment = simple_table(items)
+      ctx, fragment = simple_table(test_items)
       assert_equal example_compiled_src, ExpressTemplates.compile(&fragment)
     end
   end
 
   test "example compiled source renders the markup in the context" do
-    ctx, fragment = simple_table(items)
+    ctx, fragment = simple_table(test_items)
     assert_equal EXAMPLE_MARKUP, ctx.instance_eval(example_compiled_src)
   end
 
   test "rendered component matches desired markup" do
     ExpressTemplates::Markup::Tag.formatted do
-      ctx, fragment = simple_table(items)
+      ctx, fragment = simple_table(test_items)
       assert_equal EXAMPLE_MARKUP, ExpressTemplates.render(ctx, &fragment)
     end
   end


### PR DESCRIPTION
This fixes a bug in table_for where the id is hard-coded as "item-#{item.id}" when it should be evaluated as a variable.