### PR TITLE
[#87774814] Added edit and delete links when generating a table with actions

### DIFF
--- a/lib/express_templates/components/table_for.rb
+++ b/lib/express_templates/components/table_for.rb
@@ -84,9 +84,15 @@ module ExpressTemplates
                  class: my[:id].to_s.singularize) {
 
                 columns.each do |column|
-                  td(class: column.name) {
-                    column.format(my[:id].to_s.singularize)
-                  }
+                  if(column.has_actions?)
+                    td(class: column.name) {
+                      column.show_actions(my[:id].to_s)
+                    }
+                  else
+                    td(class: column.name) {
+                      column.format(my[:id].to_s.singularize)
+                    }
+                  end
                 end
               }
             }
@@ -109,6 +115,11 @@ module ExpressTemplates
           @options = options
           @formatter = options[:formatter]
           @header = options[:header]
+          @actions = options[:actions] || []
+        end
+
+        def has_actions?
+          @actions.any?
         end
 
         def format(item_name)
@@ -117,6 +128,19 @@ module ExpressTemplates
           elsif @formatter.kind_of?(Proc)
             "\#\{(#{@formatter.source}).call(#{item_name}.#{name})\}"
           end
+        end
+
+        def show_actions(item_name)
+          action_links = StringIO.new
+          @actions.each do |action|
+            action_name = action.to_s
+            if action_name.eql?('edit')
+              action_links.puts "<a href='/#{item_name}/{{#{item_name.singularize}.id}}/edit'>Edit</a>"
+            elsif action_name.eql?('delete')
+              action_links.puts "<a href='/#{item_name}/{{#{item_name.singularize}.id}}' data-method='delete' data-confirm='Are you sure?'>Delete</a>"
+            end
+          end
+          action_links.string
         end
 
         def title

--- a/test/components/table_for_test.rb
+++ b/test/components/table_for_test.rb
@@ -67,6 +67,75 @@ end).join+"  </tbody>
   HTML
 
 
+  EXAMPLE_WITH_ACTIONS_COMPILED = -> {
+    ExpressTemplates::Components::TableFor.render_in(self) {
+"<table id=\"test_items\">
+  <thead>
+    <tr>
+      <th class=\"name\">Name</th>
+      <th class=\"price\">Price</th>
+      <th class=\"default_actions\">Actions</th>
+    </tr>
+  </thead>
+
+  <tbody>"+(@test_items.each_with_index.map do |test_item, test_item_index|
+"
+    <tr id=\"test_item-#{test_item.id}\" class=\"test_item\">
+      <td class=\"name\">#{test_item.name}</td>
+      <td class=\"price\">#{(-> (price) { '$%0.2f' % price }).call(test_item.price)}</td>
+      <td class=\"default_actions\">
+<a href='/test_items/#{test_item.id}/edit'>Edit</a>
+<a href='/test_items/#{test_item.id}' data-method='delete' data-confirm='Are you sure?'>Delete</a>
+      </td>
+    </tr>
+"
+end).join+"  </tbody>
+</table>
+"
+}
+}
+
+  EXAMPLE_WITH_ACTIONS_MARKUP = <<-HTML
+<table id="test_items">
+  <thead>
+    <tr>
+      <th class="name">Name</th>
+      <th class="price">Price</th>
+      <th class="default_actions">Actions</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr id="test_item-1" class="test_item">
+      <td class="name">Foo</td>
+      <td class="price">$1.23</td>
+      <td class="default_actions">
+<a href='/test_items/1/edit'>Edit</a>
+<a href='/test_items/1' data-method='delete' data-confirm='Are you sure?'>Delete</a>
+      </td>
+    </tr>
+
+    <tr id="test_item-2" class="test_item">
+      <td class="name">Bar</td>
+      <td class="price">$5.49</td>
+      <td class="default_actions">
+<a href='/test_items/2/edit'>Edit</a>
+<a href='/test_items/2' data-method='delete' data-confirm='Are you sure?'>Delete</a>
+      </td>
+    </tr>
+
+    <tr id="test_item-3" class="test_item">
+      <td class="name">Baz</td>
+      <td class="price">$99.97</td>
+      <td class="default_actions">
+<a href='/test_items/3/edit'>Edit</a>
+<a href='/test_items/3' data-method='delete' data-confirm='Are you sure?'>Delete</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+  HTML
+
   def simple_table(test_items)
     ctx = Context.new(test_items)
     fragment = -> {
@@ -78,33 +147,58 @@ end).join+"  </tbody>
     return ctx, fragment
   end
 
+  def table_with_actions(test_items)
+    ctx = Context.new(test_items)
+    fragment = -> {
+      table_for(:test_items) do |t|
+        t.column :name
+        t.column :price, formatter: -> (price) { '$%0.2f' % price }
+        t.column :default_actions, header: "Actions", actions: [:edit, :delete]
+      end
+    }
+    return ctx, fragment
+  end
+
   def example_compiled_src
     # necessary because the #source method is not perfect yet
     # ideally we would have #source_body
     EXAMPLE_COMPILED.source_body
   end
 
+  def example_with_actions_compiled_src
+    EXAMPLE_WITH_ACTIONS_COMPILED.source_body
+  end
+
   test "example view code evaluates to example markup" do
     assert_equal EXAMPLE_MARKUP, Context.new(test_items).instance_eval(EXAMPLE_COMPILED.source_body)
+    assert_equal EXAMPLE_WITH_ACTIONS_MARKUP, Context.new(test_items).instance_eval(EXAMPLE_WITH_ACTIONS_COMPILED.source_body)
   end
 
   test "compiled source is legible and transparent" do
     ExpressTemplates::Markup::Tag.formatted do
       ctx, fragment = simple_table(test_items)
       assert_equal example_compiled_src, ExpressTemplates.compile(&fragment)
+
+      actx, afragment = table_with_actions(test_items)
+      assert_equal example_with_actions_compiled_src, ExpressTemplates.compile(&afragment)
     end
   end
 
   test "example compiled source renders the markup in the context" do
     ctx, fragment = simple_table(test_items)
     assert_equal EXAMPLE_MARKUP, ctx.instance_eval(example_compiled_src)
+
+    actx, afragment = table_with_actions(test_items)
+    assert_equal EXAMPLE_WITH_ACTIONS_MARKUP, actx.instance_eval(example_with_actions_compiled_src)
   end
 
   test "rendered component matches desired markup" do
     ExpressTemplates::Markup::Tag.formatted do
       ctx, fragment = simple_table(test_items)
       assert_equal EXAMPLE_MARKUP, ExpressTemplates.render(ctx, &fragment)
+
+      actx, afragment = table_with_actions(test_items)
+      assert_equal EXAMPLE_WITH_ACTIONS_MARKUP, ExpressTemplates.render(actx, &afragment)
     end
   end
-
 end


### PR DESCRIPTION
We can now add actions to a table showing resources by doing

````
table_for(:test_items) do |t|
  t.column :name
  t.column :price, formatter: -> (price) { '$%0.2f' % price }
  t.column :default_actions, header: "Actions", actions: [:edit, :delete]
end
````

Only *edit* and *delete* actions are supported for now, but in the future we can add anything to it. This also has tests living in the same context as the simple table.

One problem we encountered while doing this is that TableFor's private Column class was hard to test. We wanted to add tests to it, but will continue on with other features for now.