### PR TITLE
Bug Fix #89586218: Titlieze form labels instead of just capitalizing

### DIFF
--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -284,7 +284,7 @@ module ExpressTemplates
             field_type = field.type.to_s
             resource_field_name = "#{resource_name.singularize}[#{field_name}]"
             label_name = "#{resource_name.singularize}_#{field_name}"
-            field_label = field.label || field_name.to_s.capitalize
+            field_label = field.label || field_name.to_s.titleize
 
             div(class: field.wrapper_class) {
               if field_type == 'select'

--- a/test/components/form_for_test.rb
+++ b/test/components/form_for_test.rb
@@ -43,7 +43,7 @@ class FormForTest < ActiveSupport::TestCase
   </div>
 
   <div class=\"\">
-"+%Q(#{label_tag("resource_phone", "Phone")})+%Q(#{phone_field_tag("resource[phone]", @resource.phone, {})})+"
+"+%Q(#{label_tag("resource_mobile_phone", "Mobile Phone")})+%Q(#{phone_field_tag("resource[mobile_phone]", @resource.mobile_phone, {})})+"
   </div>
 
   <div class=\"\">
@@ -74,7 +74,7 @@ class FormForTest < ActiveSupport::TestCase
         f.text_field :name, label: 'post title'
         f.text_field :body, class: 'string'
         f.email_field :email, wrapper_class: 'field input'
-        f.phone_field :phone
+        f.phone_field :mobile_phone
         f.url_field :url
         f.number_field :number
         f.submit 'Save it!'


### PR DESCRIPTION
Currently, labels with multiple words are just capitalized like so: 'First_name'. This fix titliezes the labels for better readability.