### PR TITLE
Feature #89672780: Add more actions in form

### DIFF
--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -270,6 +270,10 @@ module ExpressTemplates
         @fields << Field.new(name, options, :submit)
       end
 
+      def actions(extra_actions)
+        @fields ||= []
+        @fields << Actions.new(extra_actions)
+      end
 
       emits -> {
         form(form_args) {
@@ -297,6 +301,18 @@ module ExpressTemplates
                 end
               elsif field_type == 'submit'
                 submit_tag(field_name, field.options)
+              elsif field_type == 'actions'
+                field.extra_actions.each do |action|
+                  action_type = action.first
+                  action_options = action.last
+
+                  if action_type == :submit
+                    submit_tag(action_options.first, action_options.last)
+                  elsif action_type == :cancel
+                    default_opts = {href: '#', onclick: 'return false;'}.merge!(action_options.last)
+                    a(default_opts) { action_options.first }
+                  end
+                end
               else
                 label_tag(label_name, field_label) unless field_type == 'hidden'
                 args = [resource_field_name, "{{@#{resource_name.singularize}.#{field_name}}}", field.options]
@@ -410,6 +426,17 @@ module ExpressTemplates
             end
             "{{'#{choice_string}'.html_safe}}"
           end
+        end
+      end
+
+      # need to fix this some day (actions doesn't need to inherit from field)
+      class Actions < Field
+        attr :extra_actions
+        def initialize(extra_actions)
+          @type = :actions
+          @name = ''
+          @label = ''
+          @extra_actions = extra_actions
         end
       end
     end

--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -270,6 +270,13 @@ module ExpressTemplates
         @fields << Field.new(name, options, :submit)
       end
 
+      # You can add extra actions to a form instead of just submit
+      # ==== Examples
+      #   f.actions({submit: ['Save', {class: 'submit primary'}], cancel: ['Cancel it', class: 'cancel secondary']})
+      #   # <div>
+      #   #   <input type="submit" name="submit primary" value: "Save" />
+      #   #   <a href="#" onclick="return false;" class="cancel secondary">Cancel it</a>
+      #   # </div>
       def actions(extra_actions)
         @fields ||= []
         @fields << Actions.new(extra_actions)


### PR DESCRIPTION
You can now add more actions in a form. We encountered this problem when trying to replicate the ajax form in express_blog#categories. The edit form had a cancel button and there was no way to put it in the same div. This feature makes that possible.