### PR TITLE
Bug Fix #90566042: add wrapper class to actions

### DIFF
--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -277,6 +277,14 @@ module ExpressTemplates
       #   #   <input type="submit" name="submit primary" value: "Save" />
       #   #   <a href="#" onclick="return false;" class="cancel secondary">Cancel it</a>
       #   # </div>
+      #
+      # You can also add extra wrapper div classes for more customization
+      # ==== Examples
+      #   f.actions({submit: ['Save', {class: 'submit primary'}], cancel: ['Cancel it', class: 'cancel secondary']}, wrapper_class: 'form-group')
+      #   # <div class='form-group'>
+      #   #   <input type="submit" name="submit primary" value: "Save" />
+      #   #   <a href="#" onclick="return false;" class="cancel secondary">Cancel it</a>
+      #   # </div>
       def actions(extra_actions, options)
         @fields ||= []
         @fields << Actions.new(extra_actions, options)

--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -277,9 +277,9 @@ module ExpressTemplates
       #   #   <input type="submit" name="submit primary" value: "Save" />
       #   #   <a href="#" onclick="return false;" class="cancel secondary">Cancel it</a>
       #   # </div>
-      def actions(extra_actions)
+      def actions(extra_actions, options)
         @fields ||= []
-        @fields << Actions.new(extra_actions)
+        @fields << Actions.new(extra_actions, options)
       end
 
       emits -> {
@@ -439,11 +439,11 @@ module ExpressTemplates
       # need to fix this some day (actions doesn't need to inherit from field)
       class Actions < Field
         attr :extra_actions
-        def initialize(extra_actions)
-          @type = :actions
+        def initialize(extra_actions, options = {})
           @name = ''
           @label = ''
           @extra_actions = extra_actions
+          super(@name, options, :actions)
         end
       end
     end

--- a/lib/express_templates/components/form_for.rb
+++ b/lib/express_templates/components/form_for.rb
@@ -385,7 +385,7 @@ module ExpressTemplates
         def initialize(name, options = {}, type=:text)
           @name = name
           @options = options
-          @label = options[:label]
+          @label = @options.delete(:label)
           @wrapper_class = @options.delete(:wrapper_class)
           @type = type
         end

--- a/lib/express_templates/version.rb
+++ b/lib/express_templates/version.rb
@@ -1,3 +1,3 @@
 module ExpressTemplates
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/test/components/form_for_test.rb
+++ b/test/components/form_for_test.rb
@@ -31,7 +31,7 @@ class FormForTest < ActiveSupport::TestCase
   </div>
 
   <div class=\"\">
-"+%Q(#{label_tag("resource_name", "post title")})+%Q(#{text_field_tag("resource[name]", @resource.name, label: "post title")})+"
+"+%Q(#{label_tag("resource_name", "post title")})+%Q(#{text_field_tag("resource[name]", @resource.name, {})})+"
   </div>
 
   <div class=\"\">
@@ -142,7 +142,7 @@ class FormForTest < ActiveSupport::TestCase
   </div>
 
   <div class=\"\">
-"+%Q(#{label_tag("resource_name", "post title")})+%Q(#{text_field_tag("resource[name]", @resource.name, label: "post title")})+"
+"+%Q(#{label_tag("resource_name", "post title")})+%Q(#{text_field_tag("resource[name]", @resource.name, {})})+"
   </div>
 
   <div class=\"\">

--- a/test/components/form_for_test.rb
+++ b/test/components/form_for_test.rb
@@ -120,7 +120,7 @@ class FormForTest < ActiveSupport::TestCase
       form_for(:resource, method: :put, url: '/posts') do |f|
         f.text_field :name, label: 'post title'
         f.text_field :body, class: 'string'
-        f.actions({submit: ['Save', {class: 'submit primary'}], cancel: ['Cancel it', class: 'cancel secondary']})
+        f.actions({submit: ['Save', {class: 'submit primary'}], cancel: ['Cancel it', class: 'cancel secondary']}, wrapper_class: 'form-group widget-buttons')
       end
     }
     return ctx, fragment
@@ -149,7 +149,7 @@ class FormForTest < ActiveSupport::TestCase
 "+%Q(#{label_tag("resource_body", "Body")})+%Q(#{text_field_tag("resource[body]", @resource.body, class: "string")})+"
   </div>
 
-  <div class=\"\">
+  <div class=\"form-group widget-buttons\">
 "+%Q(#{submit_tag("Save", class: "submit primary")})+"
     <a href=\"#\" onclick=\"return false;\" class=\"cancel secondary\">Cancel it</a>
   </div>


### PR DESCRIPTION
Expressers can now add a wrapper_class option in the form actions for more customizability